### PR TITLE
Demo on 1.4.6 cluster with Keycloak as sample HA frontend

### DIFF
--- a/50mariadb.yml
+++ b/50mariadb.yml
@@ -39,8 +39,8 @@ spec:
         - name: MYSQL_INITDB_SKIP_TZINFO
           value: "yes"
         args:
-        - --character-set-server=utf8mb4
-        - --collation-server=utf8mb4_unicode_ci
+        - --character-set-server=utf8
+        - --collation-server=utf8_unicode_ci
         volumeMounts:
         - name: datadir
           mountPath: /var/lib/mysql

--- a/bootstrap/50mariadb.yml
+++ b/bootstrap/50mariadb.yml
@@ -31,6 +31,12 @@ spec:
         - containerPort: 4568
           name: ist
         env:
+        - name: MYSQL_DATABASE
+          value: keycloak
+        - name: MYSQL_USER
+          value: keycloak
+        - name: MYSQL_PASSWORD
+          value: keycloak
         - name: MYSQL_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:

--- a/bootstrap/50mariadb.yml
+++ b/bootstrap/50mariadb.yml
@@ -43,8 +43,8 @@ spec:
         #- mysql_install_db --user=mysql --datadir=/var/lib/mysql
         args:
         - --wsrep-new-cluster
-        - --character-set-server=utf8mb4
-        - --collation-server=utf8mb4_unicode_ci
+        - --character-set-server=utf8
+        - --collation-server=utf8_unicode_ci
         volumeMounts:
         - name: datadir
           mountPath: /var/lib/mysql


### PR DESCRIPTION
Uses https://github.com/Reposoft/keycloak-ha-kubernetes/tree/meetup-demo as a samlple SQL-dependent HA frontend.

This is a pretty interesting setup, scaled to three or so pods of each, to start killing some nodes.

I used `/srv/mysql-data` as path in `./bootstrap/pv.sh`, with the result that persisted mysql data is local do each node and even suffixed per pod. Curiously unreliable.