### PR TITLE
Troubleshoot issue with first cluster start

### DIFF
--- a/20mariadb-service.yml
+++ b/20mariadb-service.yml
@@ -6,9 +6,9 @@ metadata:
   name: mariadb
   namespace: mysql
   annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "false"
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
-  publishNotReadyAddresses: false
+  publishNotReadyAddresses: true
   clusterIP: None
   selector:
     app: mariadb

--- a/50mariadb.yml
+++ b/50mariadb.yml
@@ -116,4 +116,4 @@ spec:
       storageClassName: mysql-data
       resources:
         requests:
-          storage: 2Gi
+          storage: 1Gi

--- a/50mariadb.yml
+++ b/50mariadb.yml
@@ -9,7 +9,7 @@ spec:
       app: mariadb
   serviceName: "mariadb"
   replicas: 3
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   template:
     metadata:
       labels:

--- a/50mariadb.yml
+++ b/50mariadb.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: mariadb
@@ -46,10 +46,10 @@ spec:
           mountPath: /etc/mysql/conf.d
         - name: initdb
           mountPath: /docker-entrypoint-initdb.d
-        image: mariadb:10.2.12@sha256:862de06a9b35f001e87bbefbb49008e84a59c4afd089c9a320947a9ae0e7cf1a
+        image: mariadb:10.2.14@sha256:cc58429dc130add37a006744a1eb62510396d608aeec219dbdf0befc1843daab
       containers:
       - name: mariadb
-        image: mariadb:10.2.12@sha256:862de06a9b35f001e87bbefbb49008e84a59c4afd089c9a320947a9ae0e7cf1a
+        image: mariadb:10.2.14@sha256:cc58429dc130add37a006744a1eb62510396d608aeec219dbdf0befc1843daab
         ports:
         - containerPort: 3306
           name: mysql

--- a/50mariadb.yml
+++ b/50mariadb.yml
@@ -9,7 +9,7 @@ spec:
       app: mariadb
   serviceName: "mariadb"
   replicas: 3
-  podManagementPolicy: OrderedReady
+  podManagementPolicy: Parallel
   template:
     metadata:
       labels:

--- a/configure/gke-storageclass-ssd.yml
+++ b/configure/gke-storageclass-ssd.yml
@@ -4,5 +4,6 @@ metadata:
   name: mysql-data
 provisioner: kubernetes.io/gce-pd
 reclaimPolicy: Retain
+allowVolumeExpansion: true
 parameters:
   type: pd-ssd


### PR DESCRIPTION
Having problems with a new cluster not starting up, mariadb-0 crashlooping due to lack of peers.

Workaround seems to be to delete the statefulset but keep the auto-provisioned first volume. Then create the statefulset again and upon start do "start in wsrep_new_cluster mode".