### PR TITLE
Support readonly configmap mount, k8s >= 1.9.4, 1.8.9, 1.7.14

### DIFF
--- a/10conf-d.yml
+++ b/10conf-d.yml
@@ -61,7 +61,7 @@ data:
   init.sh: |
     #!/bin/bash
     set -x
-    cp * /etc/mysql/conf.d/
+    [ "$(pwd)" != "/etc/mysql/conf.d" ] && cp * /etc/mysql/conf.d/
 
     HOST_ID=${HOSTNAME##*-}
 

--- a/10conf-d.yml
+++ b/10conf-d.yml
@@ -61,6 +61,7 @@ data:
   init.sh: |
     #!/bin/bash
     set -x
+    cp * /etc/mysql/conf.d/
 
     HOST_ID=${HOSTNAME##*-}
 

--- a/50mariadb.yml
+++ b/50mariadb.yml
@@ -121,4 +121,4 @@ spec:
       storageClassName: mysql-data
       resources:
         requests:
-          storage: 2Gi
+          storage: 1Gi

--- a/50mariadb.yml
+++ b/50mariadb.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: mariadb

--- a/50mariadb.yml
+++ b/50mariadb.yml
@@ -39,6 +39,7 @@ spec:
           value: /data/db
         - name: AUTO_NEW_CLUSTER
           value: "false"
+        workingDir: /etc/mysql/conf.d-configmap
         volumeMounts:
         - name: mysql
           mountPath: /data

--- a/50mariadb.yml
+++ b/50mariadb.yml
@@ -46,10 +46,10 @@ spec:
           mountPath: /etc/mysql/conf.d
         - name: initdb
           mountPath: /docker-entrypoint-initdb.d
-        image: mariadb:10.2.12@sha256:862de06a9b35f001e87bbefbb49008e84a59c4afd089c9a320947a9ae0e7cf1a
+        image: mariadb:10.2.15@sha256:21cbc4ff14023189c2004cd194976039318f31f2a0de11a3e2a4c85ff7c22fc1
       containers:
       - name: mariadb
-        image: mariadb:10.2.12@sha256:862de06a9b35f001e87bbefbb49008e84a59c4afd089c9a320947a9ae0e7cf1a
+        image: mariadb:10.2.15@sha256:21cbc4ff14023189c2004cd194976039318f31f2a0de11a3e2a4c85ff7c22fc1
         ports:
         - containerPort: 3306
           name: mysql

--- a/50mariadb.yml
+++ b/50mariadb.yml
@@ -21,7 +21,7 @@ spec:
       terminationGracePeriodSeconds: 30
       initContainers:
       - name: init-config
-        command: ['/bin/bash', '/etc/mysql/conf.d/init.sh']
+        command: ['/bin/bash', '/etc/mysql/conf.d-configmap/init.sh']
         env:
         - name: K8S_NODE_NAME
           valueFrom:
@@ -42,6 +42,8 @@ spec:
         volumeMounts:
         - name: mysql
           mountPath: /data
+        - name: conf-readonly
+          mountPath: /etc/mysql/conf.d-configmap
         - name: conf
           mountPath: /etc/mysql/conf.d
         - name: initdb
@@ -104,6 +106,8 @@ spec:
         - containerPort: 9104
       volumes:
       - name: conf
+        emptyDir: {}
+      - name: conf-readonly
         configMap:
           name: conf-d
       - name: initdb

--- a/configure/gke-storageclass-ssd.yml
+++ b/configure/gke-storageclass-ssd.yml
@@ -4,5 +4,6 @@ metadata:
   name: mysql-data
 provisioner: kubernetes.io/gce-pd
 reclaimPolicy: Retain
+allowVolumeExpansion: true
 parameters:
   type: pd-ssd


### PR DESCRIPTION
And upgrade to latest 10.2.

In case of a crashloop at first cluster start see #19.