### PR TITLE
Enable unattented recovery from zero replicas

### DIFF
--- a/10conf-d.yml
+++ b/10conf-d.yml
@@ -112,9 +112,9 @@ data:
           #echo "    It may not be safe to bootstrap the cluster from this node. It was not the last one to leave the cluster and may not contain all the updates. To force cluster bootstrap with this node, edit the grastate.dat file manually and set safe_to_bootstrap to 1 ."
           echo "Or to try a regular start (for example after recovery + manual intervention), run:"
           echo "  $SUGGEST_EXEC_COMMAND touch /tmp/confirm-resume"
-          if [ $HOST_ID -eq 0 ] && [ ! -z "$AUTO_RECOVERY_MODE" ]; then
-            # The !=0 hosts are assumed to start normally, with Parallel pod management policy
+          if [ ! -z "$AUTO_RECOVERY_MODE" ]; then
             echo "The AUTO_RECOVERY_MODE env was set to $AUTO_RECOVERY_MODE, will trigger that choice"
+            [ $HOST_ID -ne 0 ] && echo "ERROR Shouldn't end up here for pod index > 0 as we assume OrderedReady" && exit 1
             touch /tmp/$AUTO_RECOVERY_MODE
           else
             echo "Waiting for response ..."

--- a/10conf-d.yml
+++ b/10conf-d.yml
@@ -93,7 +93,7 @@ data:
 
     if [ $HOST_ID -eq 0 ]; then
       echo "This is the 1st statefulset pod. Checking if the statefulset is down ..."
-      getent hosts mariadb
+      getent hosts mariadb-ready
       [ $? -eq 2 ] && {
         # https://github.com/docker-library/mariadb/commit/f76084f0f9dc13f29cce48c727440eb79b4e92fa#diff-b0fa4b30392406b32de6b8ffe36e290dR80
         if [ ! -d "$DATADIR/mysql" ]; then

--- a/10conf-d.yml
+++ b/10conf-d.yml
@@ -112,11 +112,17 @@ data:
           #echo "    It may not be safe to bootstrap the cluster from this node. It was not the last one to leave the cluster and may not contain all the updates. To force cluster bootstrap with this node, edit the grastate.dat file manually and set safe_to_bootstrap to 1 ."
           echo "Or to try a regular start (for example after recovery + manual intervention), run:"
           echo "  $SUGGEST_EXEC_COMMAND touch /tmp/confirm-resume"
-          echo "Waiting for response ..."
+          if [ $HOST_ID -eq 0 ] && [ ! -z "$AUTO_RECOVERY_MODE" ]; then
+            # The !=0 hosts are assumed to start normally, with Parallel pod management policy
+            echo "The AUTO_RECOVERY_MODE env was set to $AUTO_RECOVERY_MODE, will trigger that choice"
+            touch /tmp/$AUTO_RECOVERY_MODE
+          else
+            echo "Waiting for response ..."
+          fi
           while [ ! -f /tmp/confirm-resume ]; do
-            sleep 1
             if [ "$AUTO_NEW_CLUSTER" = "true" ]; then
               echo "The AUTO_NEW_CLUSTER env was set to $AUTO_NEW_CLUSTER, will proceed without confirmation"
+              echo "NOTE this env is deprecated, use AUTO_RECOVERY_MODE instead"
               wsrepNewCluster
               touch /tmp/confirm-resume
             elif [ -f /tmp/confirm-new-cluster ]; then
@@ -133,6 +139,7 @@ data:
               wsrepRecover
               touch /tmp/confirm-resume
             fi
+            sleep 1
           done
           rm /tmp/confirm-*
           set -x

--- a/10conf-d.yml
+++ b/10conf-d.yml
@@ -114,7 +114,6 @@ data:
           echo "  $SUGGEST_EXEC_COMMAND touch /tmp/confirm-resume"
           if [ ! -z "$AUTO_RECOVERY_MODE" ]; then
             echo "The AUTO_RECOVERY_MODE env was set to $AUTO_RECOVERY_MODE, will trigger that choice"
-            [ $HOST_ID -ne 0 ] && echo "ERROR Shouldn't end up here for pod index > 0 as we assume OrderedReady" && exit 1
             touch /tmp/$AUTO_RECOVERY_MODE
           else
             echo "Waiting for response ..."

--- a/10conf-d.yml
+++ b/10conf-d.yml
@@ -145,6 +145,13 @@ data:
           set -x
         fi
       }
+    else
+      getent hosts mariadb-ready
+      [ $? -eq 2 ] && {
+        echo "This is NOT the 1st statefulset pod. Must not go up as primary."
+        echo "Found no ready pods. Will exit to trigger a crash loop back off."
+        exit 1
+      }
     fi
 
     # https://github.com/docker-library/mariadb/blob/master/10.2/docker-entrypoint.sh#L62

--- a/21mariadb-ready-service.yml
+++ b/21mariadb-ready-service.yml
@@ -1,0 +1,14 @@
+# Used with `getent hosts` to check how many pods that are ready
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mariadb-ready
+  namespace: mysql
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "false"
+spec:
+  publishNotReadyAddresses: false
+  clusterIP: None
+  selector:
+    app: mariadb

--- a/50mariadb.yml
+++ b/50mariadb.yml
@@ -37,8 +37,8 @@ spec:
               fieldPath: metadata.namespace
         - name: DATADIR
           value: /data/db
-        - name: AUTO_NEW_CLUSTER
-          value: "false"
+        - name: AUTO_RECOVERY_MODE
+          value: confirm-force-bootstrap
         - name: WSREP_CLUSTER_ADDRESS
           value: "gcomm://mariadb-0.mariadb,mariadb-1.mariadb,mariadb-2.mariadb"
         workingDir: /etc/mysql/conf.d-configmap

--- a/50mariadb.yml
+++ b/50mariadb.yml
@@ -9,7 +9,7 @@ spec:
       app: mariadb
   serviceName: "mariadb"
   replicas: 3
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   template:
     metadata:
       labels:

--- a/50mariadb.yml
+++ b/50mariadb.yml
@@ -9,7 +9,7 @@ spec:
       app: mariadb
   serviceName: "mariadb"
   replicas: 3
-  podManagementPolicy: OrderedReady
+  podManagementPolicy: Parallel
   template:
     metadata:
       labels:

--- a/50mariadb.yml
+++ b/50mariadb.yml
@@ -51,10 +51,10 @@ spec:
           mountPath: /etc/mysql/conf.d
         - name: initdb
           mountPath: /docker-entrypoint-initdb.d
-        image: mariadb:10.2.31@sha256:1e1193ba3708a73ee28c2ab56c5c6527b39ac58510d19252f020c0903aa5d86a
+        image: mariadb:10.2.32-bionic@sha256:7f9ef5c4dfd39efccbd80e6add152c672e6c63486874d83ce3f60c5a6ba33b47
       containers:
       - name: mariadb
-        image: mariadb:10.2.31@sha256:1e1193ba3708a73ee28c2ab56c5c6527b39ac58510d19252f020c0903aa5d86a
+        image: mariadb:10.2.32-bionic@sha256:7f9ef5c4dfd39efccbd80e6add152c672e6c63486874d83ce3f60c5a6ba33b47
         ports:
         - containerPort: 3306
           name: mysql

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
 - 10conf-d.yml
 - 20mariadb-service.yml
+- 21mariadb-ready-service.yml
 - 30mysql-service.yml
 - 50mariadb.yml


### PR DESCRIPTION
Running a cluster on preemptible nodes now. It's not a production critical cluster, so because of `OrderedReady` when mariadb-0 for some reason goes unready and we don't attend to it and fix it immediately any evictions on the higher ordinal pods mean they don't get scheduled again.

In this case mariadb-0 crashlooped on:

 ```
2020-04-29 04:53:38+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 1:10.2.31+maria~bionic started.
2020-04-29 04:53:38+00:00 [Note] [Entrypoint]: Switching to dedicated user 'mysql'
2020-04-29 04:53:38+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 1:10.2.31+maria~bionic started.
2020-04-29  4:53:39 140069473916608 [Note] mysqld (mysqld 10.2.31-MariaDB-1:10.2.31+maria~bionic) starting as process 1 ...
2020-04-29  4:53:39 140069473916608 [Note] WSREP: Read nil XID from storage engines, skipping position init
2020-04-29  4:53:39 140069473916608 [Note] WSREP: wsrep_load(): loading provider library '/usr/lib/galera/libgalera_smm.so'
2020-04-29  4:53:39 140069473916608 [Note] WSREP: wsrep_load(): Galera 25.3.28(r3875) by Codership Oy <info@codership.com> loaded successfully.
2020-04-29  4:53:39 140069473916608 [Note] WSREP: CRC-32C: using hardware acceleration.
2020-04-29  4:53:39 140069473916608 [Note] WSREP: Found saved state: a00fcadf-8777-11ea-b435-9e2aae01e785:-1, safe_to_bootstrap: 0
2020-04-29  4:53:39 140069473916608 [Note] WSREP: Passing config to GCS: base_dir = /data/db/; base_host = 10.24.2.35; base_port = 4567; cert.log_conflicts = no; cert.optimistic_pa = yes; debug = no; evs.auto_evict = 0; evs.delay_margin = PT1S; evs.delayed_keep_period = PT30S; evs.inactive_check_period = PT0.5S; evs.inactive_timeout = PT15S; evs.join_retrans_period = PT1S; evs.max_install_timeouts = 3; evs.send_window = 4; evs.stats_report_period = PT1M; evs.suspect_timeout = PT5S; evs.user_send_window = 2; evs.view_forget_timeout = PT24H; gcache.dir = /data/db/; gcache.keep_pages_size = 0; gcache.mem_size = 0; gcache.name = /data/db//galera.cache; gcache.page_size = 128M; gcache.recover = no; gcache.size = 128M; gcomm.thread_prio = ; gcs.fc_debug = 0; gcs.fc_factor = 1.0; gcs.fc_limit = 16; gcs.fc_master_slave = no; gcs.max_packet_size = 64500; gcs.max_throttle = 0.25; gcs.recv_q_hard_limit = 9223372036854775807; gcs.recv_q_soft_limit = 0.25; gcs.sync_donor = no; gmcast.segment = 0; gmcast.version = 0; pc.announce_timeout = PT3S; pc.checksum = false
2020-04-29  4:53:39 140069473916608 [Note] WSREP: GCache history reset: a00fcadf-8777-11ea-b435-9e2aae01e785:0 -> a00fcadf-8777-11ea-b435-9e2aae01e785:-1
2020-04-29  4:53:39 140069473916608 [Note] WSREP: Assign initial position for certification: -1, protocol version: -1
2020-04-29  4:53:39 140069473916608 [Note] WSREP: wsrep_sst_grab()
2020-04-29  4:53:39 140069473916608 [Note] WSREP: Start replication
2020-04-29  4:53:39 140069473916608 [Note] WSREP: Setting initial position to 00000000-0000-0000-0000-000000000000:-1
2020-04-29  4:53:39 140069473916608 [Note] WSREP: protonet asio version 0
2020-04-29  4:53:39 140069473916608 [Note] WSREP: Using CRC-32C for message checksums.
2020-04-29  4:53:39 140069473916608 [Note] WSREP: backend: asio
2020-04-29  4:53:39 140069473916608 [Note] WSREP: gcomm thread scheduling priority set to other:0 
2020-04-29  4:53:39 140069473916608 [Warning] WSREP: access file(/data/db//gvwstate.dat) failed(No such file or directory)
2020-04-29  4:53:39 140069473916608 [Note] WSREP: restore pc from disk failed
2020-04-29  4:53:39 140069473916608 [Note] WSREP: GMCast version 0
2020-04-29  4:53:39 140069473916608 [Warning] WSREP: Failed to resolve tcp://mariadb-1.mariadb:4567
2020-04-29  4:53:39 140069473916608 [Warning] WSREP: Failed to resolve tcp://mariadb-2.mariadb:4567
2020-04-29  4:53:39 140069473916608 [Note] WSREP: (6463191c, 'tcp://0.0.0.0:4567') listening at tcp://0.0.0.0:4567
2020-04-29  4:53:39 140069473916608 [Note] WSREP: (6463191c, 'tcp://0.0.0.0:4567') multicast: , ttl: 1
2020-04-29  4:53:39 140069473916608 [Note] WSREP: EVS version 0
2020-04-29  4:53:39 140069473916608 [Note] WSREP: gcomm: connecting to group 'my_wsrep_cluster', peer 'mariadb-0.mariadb:,mariadb-1.mariadb:,mariadb-2.mariadb:'
2020-04-29  4:53:39 140069473916608 [Note] WSREP: (6463191c, 'tcp://0.0.0.0:4567') Found matching local endpoint for a connection, blacklisting address tcp://10.24.2.35:4567
2020-04-29  4:53:42 140069473916608 [Warning] WSREP: no nodes coming from prim view, prim not possible
2020-04-29  4:53:42 140069473916608 [Note] WSREP: view(view_id(NON_PRIM,6463191c,1) memb {
	6463191c,0
} joined {
} left {
} partitioned {
})
2020-04-29  4:53:42 140069473916608 [Warning] WSREP: last inactive check more than PT1.5S ago (PT3.50167S), skipping check
2020-04-29  4:54:12 140069473916608 [Note] WSREP: view((empty))
2020-04-29  4:54:12 140069473916608 [ERROR] WSREP: failed to open gcomm backend connection: 110: failed to reach primary view: 110 (Connection timed out)
	 at gcomm/src/pc.cpp:connect():158
2020-04-29  4:54:12 140069473916608 [ERROR] WSREP: gcs/src/gcs_core.cpp:gcs_core_open():209: Failed to open backend connection: -110 (Connection timed out)
2020-04-29  4:54:12 140069473916608 [ERROR] WSREP: gcs/src/gcs.cpp:gcs_open():1458: Failed to open channel 'my_wsrep_cluster' at 'gcomm://mariadb-0.mariadb,mariadb-1.mariadb,mariadb-2.mariadb': -110 (Connection timed out)
2020-04-29  4:54:12 140069473916608 [ERROR] WSREP: gcs connect failed: Connection timed out
2020-04-29  4:54:12 140069473916608 [ERROR] WSREP: wsrep::connect(gcomm://mariadb-0.mariadb,mariadb-1.mariadb,mariadb-2.mariadb) failed: 7
2020-04-29  4:54:12 140069473916608 [ERROR] Aborting
```
Unfortunately I didn't investigate why the init-container completed, when normally it should have complained about having data but not knowing how to bootstrap. Instead I deleted the statefulset and recreated it with `Parallel`.

When scaling up from replicas 0 to 3 now mariadb-0 waits in the init container as expected. The other two crashloop, after failing to join WSREP. I think that's a pretty useful behavior. I simply ran the `kubectl exec -c init-config mariadb-0 -- touch /tmp/confirm-force-bootstrap` option logged by the init script and the cluster recovered.

Theory: To automate recovery, but accept a risk of lost writes, we could default to "confirm-force-bootstrap" on mariadb-0. With the assumption that partitioned clusters are rare the risk of lost writes should be low. Alternatively we could introduce manual start mode for all pods, so that admins can follow the MariaDB's recovery docs and decide to bootstrap the one with the newest data.


While waiting for my choice of start mode with mariadb-0 the other two pods logged the following:

```
2020-04-29  5:07:08 139926753629888 [Note] WSREP: Passing config to GCS: base_dir = /data/db/; base_host = 10.24.1.118; base_port = 4567; cert.log_conflicts = no; cert.optimistic_pa = yes; debug = no; evs.auto_evict = 0; evs.delay_margin = PT1S; evs.delayed_keep_period = PT30S; evs.inactive_check_period = PT0.5S; evs.inactive_timeout = PT15S; evs.join_retrans_period = PT1S; evs.max_install_timeouts = 3; evs.send_window = 4; evs.stats_report_period = PT1M; evs.suspect_timeout = PT5S; evs.user_send_window = 2; evs.view_forget_timeout = PT24H; gcache.dir = /data/db/; gcache.keep_pages_size = 0; gcache.mem_size = 0; gcache.name = /data/db//galera.cache; gcache.page_size = 128M; gcache.recover = no; gcache.size = 128M; gcomm.thread_prio = ; gcs.fc_debug = 0; gcs.fc_factor = 1.0; gcs.fc_limit = 16; gcs.fc_master_slave = no; gcs.max_packet_size = 64500; gcs.max_throttle = 0.25; gcs.recv_q_hard_limit = 9223372036854775807; gcs.recv_q_soft_limit = 0.25; gcs.sync_donor = no; gmcast.segment = 0; gmcast.version = 0; pc.announce_timeout = PT3S; pc.checksum = fals
2020-04-29  5:07:08 139926753629888 [Note] WSREP: GCache history reset: a00fcadf-8777-11ea-b435-9e2aae01e785:0 -> a00fcadf-8777-11ea-b435-9e2aae01e785:-1
2020-04-29  5:07:08 139926753629888 [Note] WSREP: Assign initial position for certification: -1, protocol version: -1
2020-04-29  5:07:08 139926753629888 [Note] WSREP: wsrep_sst_grab()
2020-04-29  5:07:08 139926753629888 [Note] WSREP: Start replication
2020-04-29  5:07:08 139926753629888 [Note] WSREP: Setting initial position to 00000000-0000-0000-0000-000000000000:-1
2020-04-29  5:07:08 139926753629888 [Note] WSREP: protonet asio version 0
2020-04-29  5:07:08 139926753629888 [Note] WSREP: Using CRC-32C for message checksums.
2020-04-29  5:07:08 139926753629888 [Note] WSREP: backend: asio
2020-04-29  5:07:08 139926753629888 [Note] WSREP: gcomm thread scheduling priority set to other:0 
2020-04-29  5:07:08 139926753629888 [Warning] WSREP: access file(/data/db//gvwstate.dat) failed(No such file or directory)
2020-04-29  5:07:08 139926753629888 [Note] WSREP: restore pc from disk failed
2020-04-29  5:07:08 139926753629888 [Note] WSREP: GMCast version 0
2020-04-29  5:07:08 139926753629888 [Note] WSREP: (46947ae0, 'tcp://0.0.0.0:4567') listening at tcp://0.0.0.0:4567
2020-04-29  5:07:08 139926753629888 [Note] WSREP: (46947ae0, 'tcp://0.0.0.0:4567') multicast: , ttl: 1
2020-04-29  5:07:08 139926753629888 [Note] WSREP: EVS version 0
2020-04-29  5:07:08 139926753629888 [Note] WSREP: gcomm: connecting to group 'my_wsrep_cluster', peer 'mariadb-0.mariadb:,mariadb-1.mariadb:,mariadb-2.mariadb:'
2020-04-29  5:07:08 139926753629888 [Note] WSREP: (46947ae0, 'tcp://0.0.0.0:4567') Found matching local endpoint for a connection, blacklisting address tcp://10.24.1.118:4567
2020-04-29  5:07:08 139926753629888 [Note] WSREP: (46947ae0, 'tcp://0.0.0.0:4567') connection established to 345d3b05 tcp://10.24.0.6:4567
2020-04-29  5:07:08 139926753629888 [Note] WSREP: (46947ae0, 'tcp://0.0.0.0:4567') turning message relay requesting on, nonlive peers: 
2020-04-29  5:07:09 139926753629888 [Note] WSREP: (46947ae0, 'tcp://0.0.0.0:4567') reconnecting to 345d3b05 (tcp://10.24.0.6:4567), attempt 0
2020-04-29  5:07:10 139926753629888 [Note] WSREP: (46947ae0, 'tcp://0.0.0.0:4567') connection established to 4813df72 tcp://10.24.0.6:4567
2020-04-29  5:07:10 139926753629888 [Note] WSREP: remote endpoint tcp://10.24.0.6:4567 changed identity 345d3b05 -> 4813df72
2020-04-29  5:07:13 139926753629888 [Note] WSREP: evs::proto(46947ae0, GATHER, view_id(TRANS,46947ae0,0)) suspecting node: 30eee26f
2020-04-29  5:07:13 139926753629888 [Note] WSREP: evs::proto(46947ae0, GATHER, view_id(TRANS,46947ae0,0)) suspected node without join message, declaring inactive
2020-04-29  5:07:13 139926753629888 [Note] WSREP: evs::proto(46947ae0, GATHER, view_id(TRANS,46947ae0,0)) suspecting node: 345d3b05
2020-04-29  5:07:13 139926753629888 [Note] WSREP: evs::proto(46947ae0, GATHER, view_id(TRANS,46947ae0,0)) suspecting node: 345d3b05
2020-04-29  5:07:14 139926753629888 [Note] WSREP: (46947ae0, 'tcp://0.0.0.0:4567') turning message relay requesting off
2020-04-29  5:07:14 139926753629888 [Note] WSREP: evs::proto(46947ae0, GATHER, view_id(TRANS,46947ae0,0)) suspecting node: 345d3b05
2020-04-29  5:07:14 139926753629888 [Note] WSREP: evs::proto(46947ae0, GATHER, view_id(TRANS,46947ae0,0)) suspecting node: 345d3b05
2020-04-29  5:07:15 139926753629888 [Note] WSREP: evs::proto(46947ae0, GATHER, view_id(TRANS,46947ae0,0)) suspecting node: 345d3b05
2020-04-29  5:07:15 139926753629888 [Note] WSREP: evs::proto(46947ae0, GATHER, view_id(TRANS,46947ae0,0)) suspecting node: 345d3b05
2020-04-29  5:07:16 139926753629888 [Note] WSREP: declaring 4813df72 at tcp://10.24.0.6:4567 stable
2020-04-29  5:07:16 139926753629888 [Warning] WSREP: no nodes coming from prim view, prim not possible
2020-04-29  5:07:16 139926753629888 [Note] WSREP: view(view_id(NON_PRIM,46947ae0,1) memb {
	46947ae0,0
	4813df72,0
} joined {
} left {
} partitioned {
})
```